### PR TITLE
Removed yarn

### DIFF
--- a/mac
+++ b/mac
@@ -131,7 +131,6 @@ brew "libvips"
 # Programming language prerequisites and package managers
 brew "libyaml" # should come after openssl
 brew "coreutils"
-brew "yarn"
 cask "gpg-suite-no-mail"
 
 # Databases
@@ -180,7 +179,6 @@ add_or_update_asdf_plugin() {
 . "$(brew --prefix asdf)/libexec/asdf.sh"
 add_or_update_asdf_plugin "ruby" "https://github.com/asdf-vm/asdf-ruby.git"
 add_or_update_asdf_plugin "nodejs" "https://github.com/asdf-vm/asdf-nodejs.git"
-add_or_update_asdf_plugin "yarn"
 
 install_asdf_language() {
   local language="$1"


### PR DESCRIPTION
Yarn is no longer needed as the latest version runs yarn commands locally and not globally

- Requires https://github.com/junipereducation/core/pull/5236 to be merged